### PR TITLE
Removed duplicate calculation of goodx and goody.

### DIFF
--- a/tracker.py
+++ b/tracker.py
@@ -50,7 +50,6 @@ class tracker(object):
                 bbox = boxes[y, x, :]
                 boxes[y, x, 0] = int(bbox[0]) + self.region_size/2 + self.region_size * x
                 boxes[y, x, 1] = int(bbox[1]) + self.region_size/2 + self.region_size * y
-        goodx, goody = (confidences[:,:,1] > min_confidence).nonzero()
         boxes = boxes[goodx,goody,:]
         rects, _ = cv2.groupRectangles(boxes.tolist(), 1)
         return rects


### PR DESCRIPTION
The boxes with "hologram" confidence greater than min_confidence are computed twice. To my knowledge, removing the second calculation does not alter the output of tracker.predict() and any change in time is essentially unnoticeable.